### PR TITLE
Dead end spawns

### DIFF
--- a/src/Aarau.json
+++ b/src/Aarau.json
@@ -51960,7 +51960,9 @@
       "oneway": false,
       "lanes": 1,
       "turn_lanes": [],
-      "turn_restrictions": [],
+      "turn_restrictions": [
+        "through"
+      ],
       "nodes": [
         [
           "320138174",
@@ -58103,7 +58105,9 @@
       "oneway": true,
       "lanes": 1,
       "turn_lanes": [],
-      "turn_restrictions": [],
+      "turn_restrictions": [
+        "right"
+      ],
       "nodes": [
         [
           "883432055",
@@ -59321,7 +59325,9 @@
       "oneway": true,
       "lanes": 1,
       "turn_lanes": [],
-      "turn_restrictions": [],
+      "turn_restrictions": [
+        "through"
+      ],
       "nodes": [
         [
           "1034470857",
@@ -60717,7 +60723,9 @@
       "oneway": true,
       "lanes": 1,
       "turn_lanes": [],
-      "turn_restrictions": [],
+      "turn_restrictions": [
+        "through"
+      ],
       "nodes": [
         [
           "10287833572",

--- a/src/Aarau.json
+++ b/src/Aarau.json
@@ -33210,7 +33210,7 @@
       ],
       "reversed": false,
       "oneway": true,
-      "lanes": 1,
+      "lanes": 2,
       "turn_lanes": [],
       "turn_restrictions": [],
       "nodes": [
@@ -36906,7 +36906,9 @@
       "oneway": true,
       "lanes": 1,
       "turn_lanes": [],
-      "turn_restrictions": [],
+      "turn_restrictions": [
+        "left"
+      ],
       "nodes": [
         [
           "30436824",
@@ -61918,7 +61920,9 @@
       "oneway": true,
       "lanes": 1,
       "turn_lanes": [],
-      "turn_restrictions": [],
+      "turn_restrictions": [
+        "through"
+      ],
       "nodes": [
         [
           "1789936286",

--- a/src/interface/display.h
+++ b/src/interface/display.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <vector>
 #include <cmath>
+#include <vector>
 
 #include "../simulation/car.h"
 #include "../simulation/node.h"
@@ -51,8 +51,8 @@ class Display {
           (1.5f * plot.scale) +                       // car width center
           (settings.road_width * plot.scale * 0.5f);  // center car on road
       float road_offset = car->lane_index * settings.road_width * plot.scale;
-      if (car->path.ways[car->way_index]->oneway) {
-        road_offset -= car->path.ways[car->way_index]->lanes *
+      if (car->path->ways[car->way_index]->oneway) {
+        road_offset -= car->path->ways[car->way_index]->lanes *
                        settings.road_width * plot.scale *
                        0.5f;  // if center move over by half the road width
       }

--- a/src/interface/ui.h
+++ b/src/interface/ui.h
@@ -79,6 +79,20 @@ void pathfinding(Settings& settings, Simulation& sim) {
   settings.sim.pathfinder_step_count =
       std::max(0, settings.sim.pathfinder_step_count);
 
+  if (ImGui::InputInt("Dead End Weight", &settings.sim.dead_end_weight, 1, 5)) {
+    settings.sim.dead_end_weight = std::max(0, settings.sim.dead_end_weight);
+    sim.set_dead_end_weights();
+  };
+  if (ImGui::IsItemHovered()) {
+    ImGui::BeginTooltip();
+    ImGui::Text(
+        "Determines the likelihood of dead-end roads being used by cars.");
+    ImGui::Text(
+        "Default value is the road's speed if it continues beyond the "
+        "boundary.");
+    ImGui::EndTooltip();
+  }
+
   ImGui::Text("Path count: %zu", sim.paths.size());
 }
 void highlight_selector(Settings& settings) {

--- a/src/simulation/car.h
+++ b/src/simulation/car.h
@@ -28,7 +28,7 @@ class Car {
   float accel = 20.f;
   float decel = 40.f;
   float coast_decel = 10.f;
-  Path path;
+  std::shared_ptr<const Path> path;
   int node_index;
   int way_index;
   int lane_index = 0;
@@ -36,14 +36,14 @@ class Car {
   sf::Vector2<double> direction;
   bool active = true;
   sf::Color color;
-  Car(Path path, Settings settings) : path(path) {
-    pos = path.ways[0]->nodes[0]->pos;
-    target_pos = path.ways[0]->nodes[1]->pos;
-    target_speed = path.ways[0]->speed;
+  Car(std::shared_ptr<const Path> path, Settings settings) : path(path) {
+    pos = path->ways[0]->nodes[0]->pos;
+    target_pos = path->ways[0]->nodes[1]->pos;
+    target_speed = path->ways[0]->speed;
 
     node_index = 1;
     way_index = 0;
-    add_to_way(path.ways[way_index]);
+    add_to_way(path->ways[way_index]);
     direction = get_direction(pos, target_pos, get_dist(pos, target_pos));
 
     // set start speed
@@ -180,14 +180,14 @@ class Car {
     int new_lane_index = 0;
     int min_car_count = INT_MAX;
 
-    if (way < path.turns.size()) {
-      for (size_t i = 0; i < path.ways[way]->turn_lanes.size(); i++) {
-        const auto& lane = path.ways[way]->turn_lanes[i];
+    if (way < path->turns.size()) {
+      for (size_t i = 0; i < path->ways[way]->turn_lanes.size(); i++) {
+        const auto& lane = path->ways[way]->turn_lanes[i];
         // take unrestricted or matching turns into account
         // only if valid
         if (lane.empty() || std::find(lane.begin(), lane.end(),
-                                      path.turns[way]) != lane.end()) {
-          size_t car_count = path.ways[way]->cars[i].size();
+                                      path->turns[way]) != lane.end()) {
+          size_t car_count = path->ways[way]->cars[i].size();
           if (car_count <= min_car_count) {  // prefer outer lanes on tie
             min_car_count = static_cast<int>(car_count);
             new_lane_index = static_cast<int>(i);
@@ -196,8 +196,8 @@ class Car {
       }
     }
     if (min_car_count == INT_MAX) {
-      for (size_t i = 0; i < path.ways[way]->cars.size(); i++) {
-        size_t car_count = path.ways[way]->cars[i].size();
+      for (size_t i = 0; i < path->ways[way]->cars.size(); i++) {
+        size_t car_count = path->ways[way]->cars[i].size();
         if (car_count <= min_car_count) {
           min_car_count = static_cast<int>(car_count);
           new_lane_index = static_cast<int>(i);
@@ -216,13 +216,13 @@ class Car {
     output.new_lane = lane_index;
     output.new_node += 1;
 
-    if (output.new_node >= path.ways[output.new_way]->nodes.size() &&
-        (output.new_way + 1 < path.ways.size())) {
+    if (output.new_node >= path->ways[output.new_way]->nodes.size() &&
+        (output.new_way + 1 < path->ways.size())) {
       output.new_way += 1;
       output.new_node = 1;
       output.new_lane = get_lane_index(output.new_way);
-    } else if (output.new_node >= path.ways[output.new_way]->nodes.size() &&
-               (way_index + 1 >= path.ways.size())) {
+    } else if (output.new_node >= path->ways[output.new_way]->nodes.size() &&
+               (way_index + 1 >= path->ways.size())) {
       output.new_node -= 1;
       output.end_of_path = true;
     }
@@ -262,20 +262,20 @@ class Car {
 
         if (nt.new_way != way_index) {
           // change way that this car belongs to
-          remove_from_way(path.ways[way_index]);
+          remove_from_way(path->ways[way_index]);
           way_index = nt.new_way;
           lane_index = nt.new_lane;
-          add_to_way(path.ways[way_index]);
+          add_to_way(path->ways[way_index]);
           way_progress = 0;
         }
 
         if (!nt.end_of_path) {
-          target_pos = path.ways[way_index]->nodes[node_index]->pos;
-          target_speed = path.ways[way_index]->speed;
+          target_pos = path->ways[way_index]->nodes[node_index]->pos;
+          target_speed = path->ways[way_index]->speed;
 
         } else {
           active = false;
-          remove_from_way(path.ways[way_index]);
+          remove_from_way(path->ways[way_index]);
         }
         budget -= distance;
 
@@ -302,7 +302,7 @@ class Car {
     // loop until lookahead distance has passed
 
     while (lookahead > 0 && !end && lookahead < max_dist) {
-      sf::Vector2<double> new_node = path.ways[way]->nodes[index]->pos;
+      sf::Vector2<double> new_node = path->ways[way]->nodes[index]->pos;
 
       curvature += acosf(std::clamp<float>(
                        get_dot_product(old_node, node, new_node), -1.f, 1.f)) *
@@ -324,7 +324,7 @@ class Car {
     Car* next_car = nullptr;
 
     // Check current way
-    for (auto car_in_way : path.ways[way_index]->cars[lane_index]) {
+    for (auto car_in_way : path->ways[way_index]->cars[lane_index]) {
       if (car_in_way == this) continue;
       if (car_in_way->way_progress > this->way_progress) {
         next_car = car_in_way;
@@ -334,8 +334,8 @@ class Car {
 
     // Check forward ways if needed
     if (!next_car) {
-      for (size_t i = way_index + 1; i < path.ways.size(); ++i) {
-        Way* fwd_way = path.ways[i];
+      for (size_t i = way_index + 1; i < path->ways.size(); ++i) {
+        Way* fwd_way = path->ways[i];
 
         int index = get_lane_index(i);
 

--- a/src/simulation/car.h
+++ b/src/simulation/car.h
@@ -16,7 +16,7 @@ struct new_target {
 
 struct Path {
   std::vector<Way*> ways;
-  std::vector<std::string> turns;  // same length as ways - 1
+  std::vector<Turn> turns;  // same length as ways - 1
 };
 
 class Car {

--- a/src/simulation/node.h
+++ b/src/simulation/node.h
@@ -8,6 +8,7 @@ class Way;
 class Node {
  public:
   std::string id;
+  float spawn_weight = 0.f;
   sf::Vector2<double> pos;
   int street_count;
   std::vector<Way*> ways_out;

--- a/src/simulation/pathfinder.h
+++ b/src/simulation/pathfinder.h
@@ -24,7 +24,7 @@ class Pathfinder {
   float time_searching;
   bool active = false;
   PathFinding pathfinding_mode = ASTAR;
-  std::vector<std::string> path_turns;
+  std::vector<Turn> path_turns;
 
   void reset(Node* start_node, Node* end_node, SimSettings settings) {
     start = start_node;
@@ -57,12 +57,12 @@ class Pathfinder {
       float dp = dot_product(vector1, vector2);
 
       // Simple threshold to decide turn
-      std::string turn;
+      Turn turn;
       if (dp > 0.5f) {
-        turn = "through";
+        turn = Turn::THROUGH;
       } else {
         float cross = vector1.x * vector2.y - vector1.y * vector2.x;
-        turn = (cross > 0) ? "left" : "right";
+        turn = (cross > 0) ? Turn::LEFT_TURN : Turn::RIGHT_TURN;
       }
 
       path_turns.push_back(turn);

--- a/src/simulation/simulation.h
+++ b/src/simulation/simulation.h
@@ -141,8 +141,7 @@ class Simulation {
   void change_pathfinder_mode(PathFinding new_mode) {
     settings.sim.pathfinding = new_mode;
     paths.clear();
-    pathfinder.reset(start_nodes[rand() % start_nodes.size()],
-                     end_nodes[rand() % end_nodes.size()], settings.sim);
+    reset_pathfinder();
   }
 
   void reset_pathfinder() {
@@ -152,26 +151,28 @@ class Simulation {
 
   void pathfinder_update() {
     // run x steps of A*
-    if (pathfinder.active) {
-      for (size_t i = 0; i < settings.sim.pathfinder_step_count; i++) {
+
+    for (size_t i = 0; i < settings.sim.pathfinder_step_count; i++) {
+      if (pathfinder.active) {
         pathfinder.step();
+      } else {
+        // if new path is found, add to list
+        auto& new_path = pathfinder.explored_nodes[pathfinder.end].path;
+        bool already_present = std::any_of(paths.begin(), paths.end(),
+                                           [&](const std::shared_ptr<Path>& p) {
+                                             return p->ways == new_path;
+                                           });
+        // found the endpoint
+        if (pathfinder.explored_nodes.count(pathfinder.end) &&
+            !already_present && (pathfinder.start != pathfinder.end) &&
+            !pathfinder.explored_nodes[pathfinder.end]
+                 .path.empty()) {  // different start/end node
+          paths.push_back(
+              std::make_shared<Path>(Path{new_path, pathfinder.path_turns}));
+        }
+        // start next search
+        reset_pathfinder();
       }
-    } else {
-      // if new path is found, add to list
-      auto& new_path = pathfinder.explored_nodes[pathfinder.end].path;
-      bool already_present = std::any_of(
-          paths.begin(), paths.end(),
-          [&](const std::shared_ptr<Path>& p) { return p->ways == new_path; });
-      // found the endpoint
-      if (pathfinder.explored_nodes.count(pathfinder.end) && !already_present &&
-          (pathfinder.start != pathfinder.end) &&
-          !pathfinder.explored_nodes[pathfinder.end]
-               .path.empty()) {  // different start/end node
-        paths.push_back(
-            std::make_shared<Path>(Path{new_path, pathfinder.path_turns}));
-      }
-      // start next search
-      reset_pathfinder();
     }
   }
 
@@ -204,15 +205,18 @@ class Simulation {
   void spawn_car(InputState input) {
     if (car_spawning) {
       car_timer -= input.dt;
-    } else {
-      car_timer = 0.f;
     }
-    if (car_timer < 0.f) {
+    int spawned_so_far = 0;
+    while (car_timer < 0 && spawned_so_far < 50) {  // prevent long loops
       car_timer += settings.sim.car_spawn_time;
+      ++spawned_so_far;
       if (!paths.empty() && cars.size() < settings.sim.car_cap) {
         // if paths are available, choose a random one
         std::shared_ptr<Path> path = paths[weighted_choice(paths)];
         cars.emplace_back(std::make_unique<Car>(path, settings));
+        cars.back()->update(car_timer, settings);
+      } else {
+        break;  // safety break
       }
     }
   }

--- a/src/simulation/simulation.h
+++ b/src/simulation/simulation.h
@@ -94,19 +94,48 @@ class Simulation {
   }
 
   void pathfinder_node_setup() {
+    start_nodes.clear();
+    end_nodes.clear();
     // create start and end node vectors
     for (size_t i = 0; i < nodes.size(); i++) {
+      // continous roads
       if (nodes[i].street_count == 2 && nodes[i].ways_out.size() == 1 &&
           (nodes[i].ways_out[0]->oneway && nodes[i].ways_in.size() == 0 ||
            !nodes[i].ways_out[0]->oneway && nodes[i].ways_in.size() == 1)) {
+        nodes[i].spawn_weight = nodes[i].ways_out[0]->speed;
         start_nodes.push_back(nodes[i].ways_out[0]->nodes.front());
       }
+      // dead ends separately
+      if (nodes[i].street_count == 1 && nodes[i].ways_out.size() == 1) {
+        nodes[i].spawn_weight = settings.sim.dead_end_weight;
+        start_nodes.push_back(nodes[i].ways_out[0]->nodes.front());
+      }
+      // same for ways out
       if (nodes[i].street_count == 2 && nodes[i].ways_in.size() == 1 &&
           (nodes[i].ways_in[0]->oneway && nodes[i].ways_out.size() == 0 ||
            !nodes[i].ways_in[0]->oneway && nodes[i].ways_out.size() == 1)) {
+        nodes[i].spawn_weight = nodes[i].ways_in[0]->speed;
+        end_nodes.push_back(nodes[i].ways_in[0]->nodes.back());
+      }
+
+      if (nodes[i].street_count == 1 && nodes[i].ways_in.size() == 1) {
+        nodes[i].spawn_weight = settings.sim.dead_end_weight;
         end_nodes.push_back(nodes[i].ways_in[0]->nodes.back());
       }
     }
+  }
+
+  void set_dead_end_weights() {
+    // reset dead end weights to new value
+    for (size_t i = 0; i < start_nodes.size(); i++) {
+      if (nodes[i].street_count == 1 && nodes[i].ways_out.size() == 1) {
+        nodes[i].spawn_weight = settings.sim.dead_end_weight;
+      }
+    }
+    for (size_t i = 0; i < end_nodes.size(); i++)
+      if (nodes[i].street_count == 1 && nodes[i].ways_in.size() == 1) {
+        nodes[i].spawn_weight = settings.sim.dead_end_weight;
+      }
   }
 
   void change_pathfinder_mode(PathFinding new_mode) {
@@ -145,17 +174,43 @@ class Simulation {
     }
   }
 
+  size_t weighted_choice(const std::vector<Path>& paths) {
+    float total = 0.f;
+    for (size_t i = 0; i < paths.size(); i++) {
+      total += paths[i].ways[0]->nodes[0]->spawn_weight *
+               paths[i].ways.back()->nodes.back()->spawn_weight;
+    }
+    // Random number between 0 and total
+    static std::random_device rd;
+    static std::mt19937 gen(rd());
+    std::uniform_real_distribution<float> dist(0.0f, total);
+    float value = dist(gen);
+
+    // Pick based on cumulative weight
+    float cumulative = 0.f;
+    for (size_t i = 0; i < paths.size(); ++i) {
+      cumulative += paths[i].ways[0]->nodes[0]->spawn_weight *
+                    paths[i].ways.back()->nodes.back()->spawn_weight;
+      if (value <= cumulative) {
+        return i;
+      }
+    }
+
+    // Fallback (in case of floating-point rounding)
+    return paths.size() - 1;
+  }
+
   void spawn_car(InputState input) {
     if (car_spawning) {
       car_timer -= input.dt;
     }
     int spawned_so_far = 0;
-    while (car_timer < 0 && spawned_so_far <= 7) { // prevent long loops
+    while (car_timer < 0 && spawned_so_far <= 7) {  // prevent long loops
       car_timer += settings.sim.car_spawn_time;
 
       if (paths.size() > 0 && cars.size() < settings.sim.car_cap) {
         // if paths are available, choose a random one
-        Path path = paths[rand() % paths.size()];
+        Path path = paths[weighted_choice(paths)];
         cars.emplace_back(std::make_unique<Car>(path, settings));
       }
     }

--- a/src/simulation/simulation.h
+++ b/src/simulation/simulation.h
@@ -26,7 +26,7 @@ class Simulation {
   std::vector<Node*> start_nodes;
   std::vector<Node*> end_nodes;
   std::vector<std::unique_ptr<Car>> cars = {};
-  std::vector<Path> paths;
+  std::vector<std::shared_ptr<Path>> paths;
   std::unique_ptr<Plot> plot;        // delayed construction
   std::unique_ptr<Display> display;  // delayed construction
   bool paused = false;
@@ -159,26 +159,27 @@ class Simulation {
     } else {
       // if new path is found, add to list
       auto& new_path = pathfinder.explored_nodes[pathfinder.end].path;
-      bool already_present =
-          std::any_of(paths.begin(), paths.end(),
-                      [&](const Path& p) { return p.ways == new_path; });
+      bool already_present = std::any_of(
+          paths.begin(), paths.end(),
+          [&](const std::shared_ptr<Path>& p) { return p->ways == new_path; });
       // found the endpoint
       if (pathfinder.explored_nodes.count(pathfinder.end) && !already_present &&
           (pathfinder.start != pathfinder.end) &&
           !pathfinder.explored_nodes[pathfinder.end]
                .path.empty()) {  // different start/end node
-        paths.push_back({new_path, pathfinder.path_turns});
+        paths.push_back(
+            std::make_shared<Path>(Path{new_path, pathfinder.path_turns}));
       }
       // start next search
       reset_pathfinder();
     }
   }
 
-  size_t weighted_choice(const std::vector<Path>& paths) {
+  size_t weighted_choice(std::vector<std::shared_ptr<Path>>& paths) {
     float total = 0.f;
     for (size_t i = 0; i < paths.size(); i++) {
-      total += paths[i].ways[0]->nodes[0]->spawn_weight *
-               paths[i].ways.back()->nodes.back()->spawn_weight;
+      total += paths[i]->ways[0]->nodes[0]->spawn_weight *
+               paths[i]->ways.back()->nodes.back()->spawn_weight;
     }
     // Random number between 0 and total
     static std::random_device rd;
@@ -189,8 +190,8 @@ class Simulation {
     // Pick based on cumulative weight
     float cumulative = 0.f;
     for (size_t i = 0; i < paths.size(); ++i) {
-      cumulative += paths[i].ways[0]->nodes[0]->spawn_weight *
-                    paths[i].ways.back()->nodes.back()->spawn_weight;
+      cumulative += paths[i]->ways[0]->nodes[0]->spawn_weight *
+                    paths[i]->ways.back()->nodes.back()->spawn_weight;
       if (value <= cumulative) {
         return i;
       }
@@ -203,14 +204,14 @@ class Simulation {
   void spawn_car(InputState input) {
     if (car_spawning) {
       car_timer -= input.dt;
+    } else {
+      car_timer = 0.f;
     }
-    int spawned_so_far = 0;
-    while (car_timer < 0 && spawned_so_far <= 7) {  // prevent long loops
+    if (car_timer < 0.f) {
       car_timer += settings.sim.car_spawn_time;
-
-      if (paths.size() > 0 && cars.size() < settings.sim.car_cap) {
+      if (!paths.empty() && cars.size() < settings.sim.car_cap) {
         // if paths are available, choose a random one
-        Path path = paths[weighted_choice(paths)];
+        std::shared_ptr<Path> path = paths[weighted_choice(paths)];
         cars.emplace_back(std::make_unique<Car>(path, settings));
       }
     }

--- a/src/simulation/way.h
+++ b/src/simulation/way.h
@@ -7,13 +7,15 @@ class Car;
 
 class Node;  // forward declaration
 
+enum Turn : uint8_t { THROUGH, LEFT_TURN, RIGHT_TURN };
+
 class Way {
  public:
   std::string id;
   int index;
   bool oneway;
   int lanes;
-  std::vector<std::vector<std::string>> turn_lanes;
+  std::vector<std::vector<Turn>> turn_lanes;
   std::vector<std::string> turn_restrictions;
   int speed;
   std::vector<Node*> nodes;
@@ -22,17 +24,31 @@ class Way {
   bool blocked = false;
 
   Way(std::string id, int index, bool oneway, int lanes,
-      std::vector<std::vector<std::string>> turn_lanes,
+      std::vector<std::vector<std::string>> turn_lanes_str,
       std::vector<std::string> turn_restrictions, int speed,
       std::vector<Node*>& nodes, float length)
       : id(id),
         index(index),
         oneway(oneway),
         lanes(lanes),
-        turn_lanes(turn_lanes),
+        turn_lanes(turn_lanes_str.size()),
         turn_restrictions(turn_restrictions),
         speed(speed),
         nodes(nodes),
         length(length),
-        cars(std::max(1, lanes)) {}
+        cars(std::max(1, lanes)) {
+    // convert string turn lanes to enum
+    for (size_t i = 0; i < turn_lanes_str.size(); ++i) {
+      turn_lanes[i].reserve(turn_lanes_str[i].size());
+      for (const auto& s : turn_lanes_str[i]) {
+        turn_lanes[i].push_back(string_to_turn(s));
+      }
+    }
+  }
+
+  Turn string_to_turn(const std::string& s) {
+    if (s == "left") return Turn::LEFT_TURN;
+    if (s == "right") return Turn::RIGHT_TURN;
+    return Turn::THROUGH;
+  }
 };

--- a/src/utils/settings.h
+++ b/src/utils/settings.h
@@ -22,6 +22,7 @@ struct SimSettings {
   int car_cap = 2000;
   PathFinding pathfinding = ASTAR;
   int pathfinder_step_count = 200;
+  int dead_end_weight = 1;
 };
 
 struct VisualSettings {


### PR DESCRIPTION
- Add dead ends to start/end node pool
- Add setting to change probability of dead ends being chosen as start/end node
- change paths to be stored as shared pointers, so cars don't have to copy them
- change turns list in path from string to uint8 to save memory